### PR TITLE
Add AWS architecture diagram XML

### DIFF
--- a/aws-diagram.xml
+++ b/aws-diagram.xml
@@ -1,0 +1,81 @@
+<mxfile host="app.diagrams.net">
+  <diagram name="AWS Architecture Diagram">
+    <mxGraphModel dx="1000" dy="1000" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+        
+        <!-- VPC -->
+        <mxCell id="vpcMain" value="VPC" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#ADD8E6;" vertex="1" parent="1">
+          <mxGeometry x="20" y="20" width="780" height="1120" as="geometry" />
+        </mxCell>
+        
+        <!-- Availability Zones -->
+        <mxCell id="az1" value="AZ 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#90EE90;" vertex="1" parent="vpcMain">
+          <mxGeometry x="40" y="40" width="340" height="1040" as="geometry" />
+        </mxCell>
+        <mxCell id="az2" value="AZ 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#90EE90;" vertex="1" parent="vpcMain">
+          <mxGeometry x="400" y="40" width="340" height="1040" as="geometry" />
+        </mxCell>
+        
+        <!-- Subnets -->
+        <mxCell id="frontendSubnetAz1" value="Frontend Subnet AZ 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFE0;" vertex="1" parent="az1">
+          <mxGeometry x="20" y="20" width="300" height="480" as="geometry" />
+        </mxCell>
+        <mxCell id="backendSubnetAz1" value="Backend Subnet AZ 1" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFE0;" vertex="1" parent="az1">
+          <mxGeometry x="20" y="520" width="300" height="480" as="geometry" />
+        </mxCell>
+        <mxCell id="frontendSubnetAz2" value="Frontend Subnet AZ 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFE0;" vertex="1" parent="az2">
+          <mxGeometry x="20" y="20" width="300" height="480" as="geometry" />
+        </mxCell>
+        <mxCell id="backendSubnetAz2" value="Backend Subnet AZ 2" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFE0;" vertex="1" parent="az2">
+          <mxGeometry x="20" y="520" width="300" height="480" as="geometry" />
+        </mxCell>
+        
+        <!-- EC2 Instances -->
+        <mxCell id="frontendEc2Az1" value="Frontend EC2 AZ 1" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FFA07A;" vertex="1" parent="frontendSubnetAz1">
+          <mxGeometry x="100" y="200" width="100" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="backendEc2Az1" value="Backend EC2 AZ 1" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FFA07A;" vertex="1" parent="backendSubnetAz1">
+          <mxGeometry x="100" y="200" width="100" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="frontendEc2Az2" value="Frontend EC2 AZ 2" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FFA07A;" vertex="1" parent="frontendSubnetAz2">
+          <mxGeometry x="100" y="200" width="100" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="backendEc2Az2" value="Backend EC2 AZ 2" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FFA07A;" vertex="1" parent="backendSubnetAz2">
+          <mxGeometry x="100" y="200" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <!-- Elastic Load Balancers -->
+        <mxCell id="frontendElb" value="Frontend ELB" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FF6347;" vertex="1" parent="vpcMain">
+          <mxGeometry x="340" y="20" width="100" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="backendElb" value="Backend ELB" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#FF6347;" vertex="1" parent="vpcMain">
+          <mxGeometry x="340" y="520" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <!-- RDS PostgreSQL -->
+        <mxCell id="rdsPostgresql" value="RDS PostgreSQL" style="shape=ellipse;whiteSpace=wrap;html=1;fillColor=#9370DB;" vertex="1" parent="backendSubnetAz1">
+          <mxGeometry x="100" y="400" width="100" height="60" as="geometry" />
+        </mxCell>
+        
+        <!-- Connections -->
+        <mxCell id="frontendEc2Az1ToFrontendElb" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#808080;" edge="1" parent="vpcMain" source="frontendEc2Az1" target="frontendElb">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="frontendEc2Az2ToFrontendElb" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#808080;" edge="1" parent="vpcMain" source="frontendEc2Az2" target="frontendElb">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="backendEc2Az1ToBackendElb" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#808080;" edge="1" parent="vpcMain" source="backendEc2Az1" target="backendElb">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="backendEc2Az2ToBackendElb" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#808080;" edge="1" parent="vpcMain" source="backendEc2Az2" target="backendElb">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="backendElbToRdsPostgresql" style="edgeStyle=orthogonalEdgeStyle;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;strokeColor=#808080;" edge="1" parent="vpcMain" source="backendElb" target="rdsPostgresql">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
Add XML code for AWS architecture diagram with specified components.

* Add `aws-diagram.xml` file containing the XML code for the AWS architecture diagram.
* Include 1 VPC, 2 AZs, 1 frontend and 1 backend subnet for each AZ.
* Add 1 EC2 per frontend subnet, load balanced with ELB.
* Add 1 EC2 per backend subnet, load balanced with ELB.
* Include 1 RDS PostgreSQL with multi-AZ in backend subnet.
* Connect frontend EC2s with backend ELB.
* Connect backend EC2s with RDS.
* Use AWS icons and symbols, color coding, and consistent naming conventions.

